### PR TITLE
add backports for 3.10 and implement process launching and versions

### DIFF
--- a/aiostem/__init__.py
+++ b/aiostem/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from .controller import Controller
 from .monitor import ControllerStatus, Monitor
+from .process import launch_tor, launch_tor_with_config
 from .version import version
 
 __author__ = 'Romain Bezut'
@@ -15,5 +16,7 @@ __all__ = [
     'Controller',
     'ControllerStatus',
     'Monitor',
+    'launch_tor',
+    'launch_tor_with_config',
     'version',
 ]

--- a/aiostem/command.py
+++ b/aiostem/command.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import secrets
 from collections.abc import Mapping, MutableMapping, MutableSequence
 from dataclasses import dataclass, field
-from enum import StrEnum
-from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Literal, Self, Union
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Literal, Union
 
 from pydantic import Discriminator, NonNegativeInt, Tag, TypeAdapter
 from pydantic_core import core_schema
@@ -32,11 +31,19 @@ from .structures import (
 )
 from .types import AnyHost, AnyPort, Base16Bytes, BoolYesNo
 from .utils.argument import ArgumentKeyword, ArgumentString, QuoteStyle
+from .utils.backports import StrEnum
 from .utils.transformers import TrBeforeStringSplit
 
 if TYPE_CHECKING:
     from pydantic import GetCoreSchemaHandler
     from pydantic_core.core_schema import CoreSchema, SerializerFunctionWrapHandler
+
+import sys
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 class CommandWord(StrEnum):
@@ -315,15 +322,15 @@ class CommandSerializer:
     #: End of line to use while serializing a command.
     END_OF_LINE: ClassVar[str] = '\r\n'
 
+    # in order to retain speed with the function and backport 3.10
+    # we need to make 2 different functions
+
     def __init__(self, name: CommandWord) -> None:
         """
         Create a new command serializer.
-
         This is used internally by :meth:`.Command.serialize`.
-
         Args:
             name: The command name.
-
         """
         self._body = None  # type: str | None
         self._command = name
@@ -685,9 +692,27 @@ class CommandMapAddress(Command):
 
         for key, value in addresses.items():
             args.append(ArgumentKeyword(key, value, quotes=QuoteStyle.NEVER_ENSURE))
-
         ser.arguments.extend(args)
         return ser.serialize()
+
+    if sys.version_info < (3, 11):
+
+        @classmethod
+        def __get_pydantic_core_schema__(
+            cls,
+            source: type[Any],
+            handler: GetCoreSchemaHandler,
+        ) -> CoreSchema:
+            """Create a pydantic validator and serializer for this structure."""
+
+            # XXX: We need to override since unionschemas on older versions of python don't work.
+
+            return core_schema.any_schema(
+                serialization=core_schema.wrap_serializer_function_ser_schema(
+                    function=cls._pydantic_serializer,
+                    return_schema=core_schema.str_schema(),
+                ),
+            )
 
 
 @dataclass(kw_only=True)
@@ -808,6 +833,25 @@ class CommandSetCircuitPurpose(Command):
         ser.arguments.extend(args)
         return ser.serialize()
 
+    if sys.version_info < (3, 11):
+
+        @classmethod
+        def __get_pydantic_core_schema__(
+            cls,
+            source: type[Any],
+            handler: GetCoreSchemaHandler,
+        ) -> CoreSchema:
+            """Create a pydantic validator and serializer for this structure."""
+
+            # XXX: We need to override since unionschemas on older versions of python don't work.
+
+            return core_schema.any_schema(
+                serialization=core_schema.wrap_serializer_function_ser_schema(
+                    function=cls._pydantic_serializer,
+                    return_schema=core_schema.str_schema(),
+                ),
+            )
+
 
 @dataclass(kw_only=True)
 class CommandAttachStream(Command):
@@ -849,6 +893,25 @@ class CommandAttachStream(Command):
 
         ser.arguments.extend(args)
         return ser.serialize()
+
+    if sys.version_info < (3, 11):
+
+        @classmethod
+        def __get_pydantic_core_schema__(
+            cls,
+            source: type[Any],
+            handler: GetCoreSchemaHandler,
+        ) -> CoreSchema:
+            """Create a pydantic validator and serializer for this structure."""
+
+            # XXX: We need to override since unionschemas on older versions of python don't work.
+
+            return core_schema.any_schema(
+                serialization=core_schema.wrap_serializer_function_ser_schema(
+                    function=cls._pydantic_serializer,
+                    return_schema=core_schema.str_schema(),
+                ),
+            )
 
 
 @dataclass(kw_only=True)
@@ -928,6 +991,25 @@ class CommandRedirectStream(Command):
 
         ser.arguments.extend(args)
         return ser.serialize()
+
+    if sys.version_info < (3, 11):
+
+        @classmethod
+        def __get_pydantic_core_schema__(
+            cls,
+            source: type[Any],
+            handler: GetCoreSchemaHandler,
+        ) -> CoreSchema:
+            """Create a pydantic validator and serializer for this structure."""
+
+            # XXX: We need to override since unionschemas on older versions of python don't work.
+
+            return core_schema.any_schema(
+                serialization=core_schema.wrap_serializer_function_ser_schema(
+                    function=cls._pydantic_serializer,
+                    return_schema=core_schema.str_schema(),
+                ),
+            )
 
 
 @dataclass(kw_only=True)
@@ -1078,6 +1160,25 @@ class CommandResolve(Command):
 
         ser.arguments.extend(args)
         return ser.serialize()
+
+    if sys.version_info < (3, 11):
+
+        @classmethod
+        def __get_pydantic_core_schema__(
+            cls,
+            source: type[Any],
+            handler: GetCoreSchemaHandler,
+        ) -> CoreSchema:
+            """Create a pydantic validator and serializer for this structure."""
+
+            # XXX: We need to override since unionschemas on older versions of python don't work.
+
+            return core_schema.any_schema(
+                serialization=core_schema.wrap_serializer_function_ser_schema(
+                    function=cls._pydantic_serializer,
+                    return_schema=core_schema.str_schema(),
+                ),
+            )
 
 
 @dataclass(kw_only=True)

--- a/aiostem/controller.py
+++ b/aiostem/controller.py
@@ -107,21 +107,16 @@ from .structures import (
 from .utils import Message, messages_from_stream
 
 if TYPE_CHECKING:
-    from collections.abc import (  # noqa: F401
-        Mapping,
-        MutableMapping,
-        MutableSequence,
-        Sequence,
-        Set as AbstractSet,
-    )
+    from collections.abc import Mapping, MutableMapping, MutableSequence, Sequence
+    from collections.abc import Set as AbstractSet  # noqa: F401
     from types import TracebackType
-    from typing import Self
 
     from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
     from cryptography.hazmat.primitives.asymmetric.x25519 import (
         X25519PrivateKey,
         X25519PublicKey,
     )
+    from utils.backports import Self
 
     from .types import AnyHost
 
@@ -239,7 +234,7 @@ class Controller:
         cls,
         host: str = DEFAULT_CONTROL_HOST,
         port: int = DEFAULT_CONTROL_PORT,
-    ) -> Controller:
+    ) -> Self:
         """
         Create a new controller for a remote TCP host/port.
 

--- a/aiostem/event.py
+++ b/aiostem/event.py
@@ -1,16 +1,14 @@
 from __future__ import annotations
 
 import logging
+import sys
 from abc import ABC, abstractmethod
-from collections.abc import (
-    Mapping,
-    Sequence,
-    Set as AbstractSet,
-)
+from collections.abc import Mapping, Sequence
+from collections.abc import Set as AbstractSet
 from dataclasses import dataclass, field
-from enum import StrEnum
+from enum import Enum
 from functools import cached_property
-from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Literal, Self, TypeAlias, Union
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Literal, TypeAlias, Union
 
 from pydantic import BeforeValidator, Discriminator, Field, NonNegativeInt, Tag, TypeAdapter
 
@@ -85,10 +83,17 @@ from .utils import (
     MessageData,
     ReplySyntax,
     ReplySyntaxFlag,
+    StrEnum,
     TrBeforeSetToNone,
     TrBeforeStringSplit,
     TrCast,
 )
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
 
 if TYPE_CHECKING:
     # The following line is needed so sphinx can get EventConfChanged right.
@@ -1608,7 +1613,7 @@ class EventStatus(Event):
         LogSeverity,
     ]
     #: Status action reported by this event (sub-classed).
-    action: StrEnum
+    action: Enum
 
     @classmethod
     def from_message(cls, message: Message) -> Self:

--- a/aiostem/process.py
+++ b/aiostem/process.py
@@ -1,0 +1,455 @@
+# Copyright 2011-2019, Damian Johnson and The Tor Project
+# See LICENSE for licensing information
+
+# Modified by Vizonex, 2025
+
+"""
+Helper functions for working with tor as a process.
+
+:NO_TORRC:
+  when provided as a torrc_path tor is ran with a blank configuration
+
+:DEFAULT_INIT_TIMEOUT:
+  number of seconds before we time out our attempt to start a tor instance
+
+**Module Overview:**
+
+::
+
+  launch_tor             - starts up a tor process
+  launch_tor_with_config - starts a tor process with a custom torrc
+"""
+
+import asyncio
+import os
+import re
+import sys
+import tempfile
+import typing as t  # Only reason for "t" prefix is due to the number of objects needed.
+from contextlib import suppress
+from functools import wraps
+from types import TracebackType
+
+import async_timeout
+from aiofiles import open as aopen
+from aiosignal import Signal
+
+from . import system, version
+from .types import P  # Import ParamSpec varaible for typehinting wrappers.
+
+NO_TORRC = '<no torrc>'
+DEFAULT_INIT_TIMEOUT = 90
+
+
+class MessageHandler:
+    """A Special handler for aiosteam for handling callbacks
+    related to launching tor."""
+
+    def __init__(self) -> None:
+        self._on_message: Signal[str] = Signal(self)
+
+    @property
+    def on_message(self):
+        """
+        Called when a message is being sent from launching tor::
+
+            from aiostem.process import launch_tor_with_config, MessageHandler
+
+            events = MessageHandler()
+
+            @events.on_message
+            async def on_message(msg:str):
+                print(f"message: {msg}")
+
+            events.freeze()
+
+        """
+        return self._on_message
+
+    @property
+    def frozen(self) -> bool:
+        """Determines if events were already frozen"""
+        return self._on_message.frozen
+
+    def freeze(self) -> None:
+        """Freezes the events"""
+        self.on_message.freeze()
+
+    async def send(self, msg: str) -> None:
+        """Sends message to different events if provided"""
+        return await self.on_message.send(msg)
+
+
+Process = asyncio.subprocess.Process
+
+
+class _ProcessContextManager(t.Coroutine[t.Any, t.Any, Process]):
+    """Inspired by aiohttp's technqiues but for handling tor processes"""
+
+    __slots__ = ('_coro', '_resp')
+
+    def __init__(self, coro: t.Coroutine[asyncio.Future[t.Any], None, Process]) -> None:
+        self._coro: t.Coroutine[asyncio.Future[t.Any], None, Process] = coro
+
+    def send(self, arg: None) -> asyncio.Future[t.Any]:
+        return self._coro.send(arg)
+
+    def throw(self, *args: t.Any, **kwargs: t.Any) -> asyncio.Future[Process]:
+        return self._coro.throw(*args, **kwargs)
+
+    def close(self) -> None:
+        return self._coro.close()
+
+    def __await__(self) -> t.Generator[t.Any, None, Process]:
+        ret = self._coro.__await__()
+        return ret
+
+    def __iter__(self) -> t.Generator[t.Any, None, Process]:
+        return self.__await__()
+
+    async def __aenter__(self) -> Process:
+        self._resp: Process = await self._coro
+        return self._resp
+
+    async def __aexit__(
+        self,
+        exc_type: t.Optional[t.Type[BaseException]],
+        exc: t.Optional[BaseException],
+        tb: t.Optional[TracebackType],
+    ) -> None:
+        # Terminate even if process was already finished beforehand.
+        with suppress(Exception):
+            self._resp.terminate()
+
+
+def _wrap_process(
+    func: t.Callable[P, t.Coroutine[t.Any, t.Any, asyncio.subprocess.Process]],
+):
+    """Wrap a process launching function to be used via await or asynchronous context manager"""
+
+    @wraps(func)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> _ProcessContextManager:
+        return _ProcessContextManager(func(*args, **kwargs))
+
+    return wrapper
+
+
+@_wrap_process
+async def launch_tor(
+    tor_cmd: str = 'tor',
+    args: list[str] = [],
+    torrc_path: t.Optional[str] = None,
+    completion_percent: int = 100,
+    init_msg_handler: t.Optional[MessageHandler] = None,
+    timeout: t.Optional[float] = DEFAULT_INIT_TIMEOUT,
+    take_ownership: bool = False,
+    close_output: bool = True,
+    stdin: t.Union[str, bytes, None] = None,
+) -> Process:
+    """
+    Initializes a tor process. This blocks until initialization completes or we
+    error out.
+
+    If tor's data directory is missing or stale then bootstrapping will include
+    making several requests to the directory authorities which can take a little
+    while. Usually this is done in 50 seconds or so, but occasionally calls seem
+    to get stuck, taking well over the default timeout.
+
+    **To work to must log at NOTICE runlevel to stdout.** It does this by
+    default, but if you have a 'Log' entry in your torrc then you'll also need
+    'Log NOTICE stdout'.
+
+    Note: The timeout argument does not work on Windows or when outside the
+    main thread, and relies on the global state of the signal module.
+
+    .. versionchanged:: 1.6.0
+       Allowing the timeout argument to be a float.
+
+    .. versionchanged:: 1.7.0
+       Added the **close_output** argument.
+
+    :param str tor_cmd: command for starting tor
+    :param list args: additional arguments for tor
+    :param str torrc_path: location of the torrc for us to use
+    :param int completion_percent: percent of bootstrap completion at which
+      this'll return
+    :param MessageHandler | None init_msg_handler: optional functor that will be provided with
+      tor's initialization stdout as we get it
+    :param int timeout: time after which the attempt to start tor is aborted, no
+      timeouts are applied if **None**
+    :param bool take_ownership: asserts ownership over the tor process so it
+      aborts if this python process terminates or a :class:`~stem.control.Controller`
+      we establish to it disconnects
+    :param bool close_output: closes tor's stdout and stderr streams when
+      bootstrapping is complete if true
+    :param str | bytes | None stdin: content to provide on stdin
+
+    :returns: **subprocess.Popen** instance for the tor subprocess
+
+    :raises: **OSError** if we either fail to create the tor process or reached a
+      timeout without success
+    """
+    if init_msg_handler and not init_msg_handler.frozen:
+        # Freeze now and not later...
+        init_msg_handler.freeze()
+
+    # sanity check that we got a tor binary
+
+    if os.path.sep in tor_cmd:
+        # got a path (either relative or absolute), check what it leads to
+        if os.path.isdir(tor_cmd):
+            raise OSError("'%s' is a directory, not the tor executable" % tor_cmd)
+        elif not os.path.isfile(tor_cmd):
+            raise OSError("'%s' doesn't exist" % tor_cmd)
+    elif not system.is_available(tor_cmd):
+        raise OSError(
+            "'%s' Doesn't exit"  # Less vauge than what stem python has
+            % tor_cmd
+        )
+
+    # double check that we have a torrc to work with
+    if torrc_path not in (None, NO_TORRC) and not os.path.exists(torrc_path):
+        raise OSError("torrc doesn't exist (%s)" % torrc_path)
+
+    # starts a tor subprocess, raising an OSError if it fails
+    runtime_args, temp_file = [tor_cmd], None
+
+    if args:
+        runtime_args.extend(args)
+
+    if torrc_path:
+        runtime_args.append('-f')
+        if torrc_path == NO_TORRC:
+            temp_file = (
+                await asyncio.to_thread(tempfile.mkstemp, prefix='empty-torrc-', text=True)
+            )[1]
+            runtime_args.append(temp_file)
+        else:
+            runtime_args.append(torrc_path)
+
+    if take_ownership:
+        runtime_args += ['__OwningControllerProcess', str(os.getpid())]
+
+    tor_process = None
+
+    try:
+        tor_process = await asyncio.subprocess.create_subprocess_exec(
+            *runtime_args,
+            stdout=asyncio.subprocess.PIPE,
+            stdin=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        if stdin:
+            # send asynchronously
+            tor_process.stdin.write(stdin.encode('utf-8') if isinstance(stdin, str) else stdin)
+            await tor_process.stdin.drain()
+
+        # we can use async_timeout as a backport for earlier versions of Python 3
+        async with async_timeout.timeout(timeout):
+            bootstrap_line = re.compile('Bootstrapped ([0-9]+)%')
+            problem_line = re.compile('\\[(warn|err)\\] (.*)$')
+            last_problem = 'Timed out'
+
+            while True:
+                # Tor's stdout will be read as ASCII bytes. This is fine for python 2, but
+                # in python 3 that means it'll mismatch with other operations (for instance
+                # the bootstrap_line.search() call later will fail).
+
+                init_line = (
+                    (await tor_process.stdout.readline()).decode('utf-8', 'replace').strip()
+                )
+
+                # this will provide empty results if the process is terminated
+
+                if not init_line:
+                    tor_process.terminate()
+                    raise OSError('Process terminated: %s' % last_problem)
+
+                # provide the caller with the initialization message if they want it
+
+                if init_msg_handler:
+                    await init_msg_handler.send(init_line)
+
+                # return the process if we're done with bootstrapping
+
+                bootstrap_match = bootstrap_line.search(init_line)
+                problem_match = problem_line.search(init_line)
+
+                if bootstrap_match and int(bootstrap_match.group(1)) >= completion_percent:
+                    print('RETURN')
+                    return tor_process
+                elif problem_match:
+                    runlevel, msg = problem_match.groups()
+
+                    if 'see warnings above' not in msg:
+                        if ': ' in msg:
+                            msg = msg.split(': ')[-1].strip()
+
+                        last_problem = msg
+    except Exception as e:
+        if tor_process:
+            tor_process.kill()  # don't leave a lingering process
+            await tor_process.wait()
+        raise e  # Raise exception from before
+    finally:
+        # Do not kill process yet
+        # print("CLEANUP")
+        # if tor_process and close_output:
+        #     # needs killing since no returncode was issued
+        #     tor_process.kill()
+
+        if temp_file:
+            try:
+                # protect from failing...
+                await asyncio.shield(asyncio.to_thread(os.remove, temp_file))
+            except Exception:
+                pass
+
+
+@_wrap_process
+async def launch_tor_with_config(
+    config: dict[str, t.Union[list[t.Union[str, int]], str, int]],
+    tor_cmd: str = 'tor',
+    completion_percent=100,
+    init_msg_handler: t.Optional[MessageHandler] = None,
+    timeout: t.Optional[float] = DEFAULT_INIT_TIMEOUT,
+    take_ownership: bool = False,
+    close_output: bool = True,
+) -> Process:
+    """
+    Initializes a tor process, like :func:`~stem.process.launch_tor`, but with a
+    customized configuration. This writes a temporary torrc to disk, launches
+    tor, then deletes the torrc.
+
+    For example...
+
+    ::
+
+      tor_process = aiostem.process.launch_tor_with_config(
+        config = {
+          'ControlPort': '2778',
+          'Log': [
+            'NOTICE stdout',
+            'ERR file /tmp/tor_error_log',
+          ],
+        },
+      )
+
+      # Or this way which is encouraged over await
+        async with aiostem.process.launch_tor_with_config(
+            config = {
+              'ControlPort': '2778',
+              'Log': [
+                'NOTICE stdout',
+                'ERR file /tmp/tor_error_log',
+              ],
+            },
+        ) as tor_process: ...
+
+
+    :param dict config: configuration options, such as "{'ControlPort': '9051'}" or with a MultiDict,
+      values can either be a **str** or **list of str** if for multiple values
+    :param str tor_cmd: command for starting tor
+    :param int completion_percent: percent of bootstrap completion at which
+      this'll return
+    :param functor init_msg_handler: optional functor that will be provided with
+      tor's initialization stdout as we get it
+    :param float timeout: time after which the attempt to start tor is aborted, no
+      timeouts are applied if **None**
+    :param bool take_ownership: asserts ownership over the tor process so it
+      aborts if this python process terminates or a :class:`~stem.control.Controller`
+      we establish to it disconnects
+    :param bool close_output: closes tor's stdout and stderr streams when
+      bootstrapping is complete if true
+
+    :returns: **asyncio.subprocess.Process** instance for the tor subprocess
+
+    :raises: **OSError | asyncio.TimeoutError** if we either fail to create the tor process or reached a
+      timeout without success
+    """
+
+    # TODO: Drop this version check when tor 0.2.6.3 or higher is the only game
+    # in town.
+
+    try:
+        use_stdin = (
+            await version.get_system_tor_version(tor_cmd)
+        ) >= version.Requirement.TORRC_VIA_STDIN
+    except IOError:
+        use_stdin = False
+
+    # we need to be sure that we're logging to stdout to figure out when we're
+    # done bootstrapping
+
+    if 'Log' in config:
+        # Transformed to a frozenset for extra speed
+        stdout_options = {'DEBUG stdout', 'INFO stdout', 'NOTICE stdout'}
+
+        # if were not using Multidict (although encouraged over other ways)
+        # revert to the older system of dict[str, list[...]]
+        if isinstance(config['Log'], str):
+            config['Log'] = [config['Log']]
+
+        has_stdout = False
+
+        for log_config in config['Log']:
+            if log_config in stdout_options:
+                has_stdout = True
+                break
+
+        if not has_stdout:
+            config['Log'].append('NOTICE stdout')
+
+    config_str = ''
+
+    for key, values in config.items():
+        if isinstance(values, str):
+            config_str += '%s %s\n' % (key, values)
+        elif isinstance(values, int):
+            config_str += '%s %i\n' % (key, values)
+        else:
+            for value in values:
+                if isinstance(value, str):
+                    config_str += '%s %s\n' % (key, value)
+                elif isinstance(value, int):
+                    config_str += '%s %i\n' % (key, value)
+                else:
+                    raise TypeError(f'{value!r} Is an unacceptable type')
+
+    if use_stdin:
+        return await launch_tor(
+            tor_cmd,
+            ['-f', '-'],
+            None,
+            completion_percent,
+            init_msg_handler,
+            timeout,
+            take_ownership,
+            close_output,
+            stdin=config_str,
+        )
+    else:
+        torrc_fd, torrc_path = await asyncio.to_thread(
+            tempfile.mkstemp, prefix='torrc-', text=True
+        )
+
+        try:
+            # make async with aiofiles.open as 'aopen'
+            async with aopen(torrc_path, 'w') as torrc_file:
+                await torrc_file.write(config_str)
+
+            return await launch_tor(
+                tor_cmd,
+                # prevents tor from erroring out due to a missing torrc if it gets a sighup
+                ['__ReloadTorrcOnSIGHUP', '0'],
+                torrc_path,
+                completion_percent,
+                init_msg_handler,
+                timeout,
+                take_ownership,
+            )
+        finally:
+            with suppress(Exception):
+                await asyncio.shield(asyncio.to_thread(os.close, torrc_fd))
+                await asyncio.shield(asyncio.to_thread(os.remove, torrc_path))

--- a/aiostem/reply.py
+++ b/aiostem/reply.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sys
 from abc import ABC, abstractmethod
 from collections.abc import (
     ItemsView,
@@ -14,7 +15,7 @@ from collections.abc import (
 )
 from dataclasses import dataclass, field
 from functools import partial
-from typing import Any, ClassVar, Self, TypeAlias, TypeVar
+from typing import Any, ClassVar, TypeAlias, TypeVar
 
 from pydantic import PositiveInt, TypeAdapter
 
@@ -28,6 +29,11 @@ from .structures import (
     ReplyDataProtocolInfo,
 )
 from .utils import BaseMessage, Message, ReplySyntax, ReplySyntaxFlag
+
+if sys.version_info < (3, 11):
+    from typing_extensions import Self
+else:
+    from typing import Self
 
 logger = logging.getLogger(__package__)
 

--- a/aiostem/structures.py
+++ b/aiostem/structures.py
@@ -6,17 +6,14 @@ import hmac
 import logging
 import secrets
 import struct
+import sys
 from abc import ABC, abstractmethod
-from collections.abc import (
-    Iterator,
-    Mapping,
-    Sequence,
-    Set as AbstractSet,
-)
+from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Set as AbstractSet
 from contextlib import suppress
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
-from enum import IntEnum, IntFlag, StrEnum
+from datetime import datetime, timedelta, timezone
+from enum import IntEnum, IntFlag
 from functools import cache, cached_property, wraps
 from ipaddress import IPv4Address, IPv6Address
 from typing import (
@@ -26,11 +23,17 @@ from typing import (
     ClassVar,
     Literal,
     Optional,
-    Self,
     TypeAlias,
     Union,
     cast,
 )
+
+from .utils.backports import UTC, StrEnum
+
+if sys.version_info < (3, 11):
+    from typing_extensions import Self
+else:
+    from typing import Self
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives.asymmetric.ed25519 import (

--- a/aiostem/system.py
+++ b/aiostem/system.py
@@ -1,0 +1,142 @@
+import asyncio
+import os
+import sys
+from shlex import split
+from typing import Any, Optional, Union
+
+import async_timeout
+
+UNDEFINED = '<Undefined_ >'
+
+PIPE = asyncio.subprocess.PIPE
+
+
+class CallError(Exception):
+    pass
+
+
+async def call(
+    command: Union[str, list[str]],
+    # To remain asynchronous and threadsafe I just moved the whole string in here
+    default='<Undefined_ >',
+    ignore_exit_status=False,
+    timeout: Optional[int] = None,
+    cwd: Optional[Union[str, bytes]] = None,
+    env: Optional[dict[str, Any]] = None,
+):
+    """
+    call(command, default = UNDEFINED, ignore_exit_status = False)
+
+    Issues a command in a subprocess, blocking until completion and returning the
+    results. This is not actually ran in a shell so pipes and other shell syntax
+    are not permitted.
+
+    .. versionchanged:: 1.5.0
+       Providing additional information upon failure by raising a CallError. This
+       is a subclass of OSError, providing backward compatibility.
+
+    .. versionchanged:: 1.5.0
+       Added env argument.
+
+    .. versionchanged:: 1.6.0
+       Added timeout and cwd arguments.
+
+    :param str,list command: command to be issued
+    :param object default: response if the query fails
+    :param bool ignore_exit_status: reports failure if our command's exit status
+      was non-zero
+    :param float timeout: maximum seconds to wait, blocks indefinitely if
+      **None**
+    :param dict env: environment variables
+
+    :returns: **list** with the lines of output from the command
+
+    :raises:
+      * **CallError** if this fails and no default was provided
+      * **TimeoutError** if the timeout is reached without a default via async_timeout
+    """
+
+    if isinstance(command, str):
+        command_list = split(command, posix=False)
+    else:
+        command_list = list(map(str, command))
+
+    process = exit_status = stdout = stderr = None
+    try:
+        if command_list[0] == 'ulimit':
+            process = await asyncio.subprocess.create_subprocess_shell(
+                command_list, stdout=PIPE, stderr=PIPE, cwd=cwd, env=env, shell=True
+            )
+        else:
+            process = await asyncio.subprocess.create_subprocess_exec(
+                *command_list,
+                stdout=PIPE,
+                stderr=PIPE,
+                cwd=cwd,
+                env=env,
+                shell=False,
+            )
+        async with async_timeout.timeout(timeout):
+            stdout, stderr = await process.communicate()
+        stdout, stderr = stdout.strip(), stderr.strip()
+
+        exit_status = await process.wait()
+        if not ignore_exit_status and exit_status != 0:
+            raise OSError('%s returned exit status %i' % (command, exit_status))
+
+        return stdout.decode('utf-8', 'replace').splitlines() if stdout else []
+    except Exception as exc:
+        if not process.returncode:
+            # TimeoutError if no returncode so we kill instead
+            process.kill()
+
+        if default == '<Undefined_ >':
+            raise CallError(str(exc), ' '.join(command_list), exit_status) from exc
+        else:
+            return default
+
+
+CMD_AVAILABLE_CACHE = {}
+
+
+def is_available(command: str, cached: bool = True):
+    """
+    Checks the current PATH to see if a command is available or not. If more
+    than one command is present (for instance "ls -a | grep foo") then this
+    just checks the first.
+
+    Note that shell (like cd and ulimit) aren't in the PATH so this lookup will
+    try to assume that it's available. This only happends for recognized shell
+    commands (those in SHELL_COMMANDS).
+
+    :param str command: command to search for
+    :param bool cached: makes use of available cached results if **True**
+
+    :returns: **True** if an executable we can use by that name exists in the
+      PATH, **False** otherwise
+    """
+
+    if ' ' in command:
+        command = command[: command.find(' ')]
+
+    if command == 'ulimit':
+        return True  # we can't actually look it up, so hope the shell really provides it...
+    elif cached and command in CMD_AVAILABLE_CACHE:
+        return CMD_AVAILABLE_CACHE[command]
+    elif 'PATH' not in os.environ:
+        return False  # lacking a path will cause find_executable() to internally fail
+
+    cmd_exists = False
+
+    for path in os.environ['PATH'].split(os.pathsep):
+        cmd_path = os.path.join(path, command)
+
+        if sys.platform == 'win32' and not cmd_path.endswith('.exe'):
+            cmd_path += '.exe'
+
+        if os.path.exists(cmd_path) and os.access(cmd_path, os.X_OK):
+            cmd_exists = True
+            break
+
+    CMD_AVAILABLE_CACHE[command] = cmd_exists
+    return cmd_exists

--- a/aiostem/types.py
+++ b/aiostem/types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from datetime import datetime, timedelta
 from ipaddress import IPv4Address, IPv6Address
 from typing import Annotated, Generic, TypeAlias, TypeVar, Union
@@ -23,8 +24,16 @@ from .utils import (
     TrX25519PublicKey,
 )
 
+if sys.version_info < (3, 10):
+    from typing_extensions import ParamSpec
+else:
+    from typing import ParamSpec
+
 #: Any boundary of a range structure (int, float, etc...).
 RangeVal = TypeVar('RangeVal')
+
+T = TypeVar('T')
+P = ParamSpec('P')
 
 
 # Generic models do not work well with dataclasses even on recent pydantic :(.
@@ -38,11 +47,13 @@ class GenericRange(BaseModel, Generic[RangeVal]):
 
 
 #: Any IP address, either IPv4 or IPv6.
-AnyAddress: TypeAlias = Union[IPv4Address | IPv6Address]  # noqa: UP007
+AnyAddress: TypeAlias = Union[IPv4Address, IPv6Address]  # noqa: UP007
 
 #: Any host, either by IP address or hostname.
 AnyHost: TypeAlias = Annotated[
-    IPv4Address | IPv6Address | str,
+    IPv4Address,
+    IPv6Address,
+    str,
     Field(union_mode='left_to_right'),
 ]
 #: Any TCP or UDP port.

--- a/aiostem/utils/__init__.py
+++ b/aiostem/utils/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from .argument import ArgumentKeyword, ArgumentString, QuoteStyle
+from .backports import UTC, Self, StrEnum
 from .encoding import (
     Base16Encoder,
     Base32Encoder,
@@ -42,6 +43,8 @@ __all__ = [
     'QuoteStyle',
     'ReplySyntax',
     'ReplySyntaxFlag',
+    'Self',
+    'StrEnum',
     'TrAfterAsTimezone',
     'TrBeforeSetToNone',
     'TrBeforeStringSplit',
@@ -54,5 +57,6 @@ __all__ = [
     'TrRSAPublicKey',
     'TrX25519PrivateKey',
     'TrX25519PublicKey',
+    'UTC',
     'messages_from_stream',
 ]

--- a/aiostem/utils/argument.py
+++ b/aiostem/utils/argument.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import re
 from abc import ABC, abstractmethod
-from enum import IntEnum, StrEnum
+from enum import Enum, IntEnum
 from ipaddress import IPv4Address, IPv6Address
 from typing import TYPE_CHECKING, Any, TypeAlias, Union, overload
 
+from .backports import StrEnum
+
 if TYPE_CHECKING:
     from collections.abc import Set as AbstractSet
-
 
 from ..exceptions import CommandError
 

--- a/aiostem/utils/backports.py
+++ b/aiostem/utils/backports.py
@@ -1,0 +1,26 @@
+# Backports for version 3.10
+
+import sys
+
+if sys.version_info < (3, 11):
+    from datetime import timezone
+    from enum import Enum
+    from typing_extensions import Self
+
+    UTC = timezone.utc
+
+    class StrEnum(str, Enum):
+        # XXX: To Ensure Serlization works correctly so some adjustments had to be made.
+        def __str__(self) -> str:
+            return self._value_
+
+else:
+    from datetime import UTC
+    from enum import StrEnum
+    from typing import Self
+
+__all__ = (
+    'Self',
+    'StrEnum',
+    'UTC',
+)

--- a/aiostem/utils/syntax.py
+++ b/aiostem/utils/syntax.py
@@ -2,12 +2,8 @@ from __future__ import annotations
 
 import logging
 from collections import OrderedDict
-from collections.abc import (
-    Iterable,
-    Mapping,
-    Sequence,
-    Set as AbstractSet,
-)
+from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Set as AbstractSet
 from dataclasses import dataclass, field
 from enum import IntFlag
 from typing import TYPE_CHECKING

--- a/aiostem/utils/transformers.py
+++ b/aiostem/utils/transformers.py
@@ -3,15 +3,11 @@ from __future__ import annotations
 import hashlib
 import typing
 from abc import ABC, abstractmethod
-from collections.abc import (
-    Collection,
-    Mapping,
-    MutableSequence,  # noqa: F401
-    Sequence,
-    Set as AbstractSet,
-)
+from collections.abc import MutableSequence  # noqa: F401
+from collections.abc import Collection, Mapping, Sequence
+from collections.abc import Set as AbstractSet
 from dataclasses import dataclass, field
-from datetime import UTC, datetime, timedelta, tzinfo
+from datetime import datetime, timedelta, tzinfo
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, Literal, TypeVar
 
 from cryptography.hazmat.primitives.asymmetric.ed25519 import (
@@ -31,6 +27,8 @@ from cryptography.hazmat.primitives.serialization import (
 from pydantic import ConfigDict
 from pydantic_core import core_schema
 from pydantic_core.core_schema import CoreSchema, WhenUsed
+
+from .backports import UTC
 
 if TYPE_CHECKING:
     from pydantic import GetCoreSchemaHandler

--- a/aiostem/version.py
+++ b/aiostem/version.py
@@ -1,3 +1,404 @@
-from __future__ import annotations
+"""
+asynchronous version of the stem library's version getter
+"""
 
-version: str = '0.4.4'
+import asyncio
+import os
+import re
+from enum import Enum
+from functools import lru_cache, total_ordering
+from typing import Callable, Hashable
+
+from async_lru import alru_cache
+
+from .system import call
+
+VERSION_PATTERN = re.compile(r'^([0-9]+)\.([0-9]+)\.([0-9]+)(\.[0-9]+)?(-\S*)?(( \(\S*\))*)$')
+
+UNDEFINED = '<Undefined_ >'
+
+version = '0.4.4'
+
+# TODO: Reduce globals and contsants for speed and being threadsafe at all costs
+
+
+@alru_cache(typed=False)
+async def get_system_tor_version(tor_cmd='tor') -> 'Version':
+    """
+    Queries tor for its version. This is os dependent, only working on linux,
+    osx, and bsd.
+
+    :param str tor_cmd: command used to run tor
+
+    :returns: :class:`~aiostem.version.Version` provided by the tor command
+
+    :raises: **IOError** if unable to query or parse the version
+
+    In `aiostem` this is now an `alru_cache` using the `async_lru` library.
+    to help remain threadsafe
+    """
+
+    version_cmd = '%s --version' % tor_cmd
+
+    try:
+        version_output = await call(version_cmd)
+
+    except OSError as exc:
+        # make the error message nicer if this is due to tor being unavialable
+        if 'No such file or directory' in str(exc):
+            if await asyncio.to_thread(os.path.isabs, tor_cmd):
+                exc = "Unable to check tor's version. '%s' doesn't exist." % tor_cmd
+            else:
+                exc = "Unable to run '%s'. Maybe tor isn't in your PATH?" % version_cmd
+        raise IOError(exc)
+
+    for line in version_output:
+        # output example:
+        # Oct 21 07:19:27.438 [notice] Tor v0.2.1.30. This is experimental software. Do not rely on it for strong anonymity. (Running on Linux i686)
+        # Tor version 0.2.1.30.
+        if line.startswith('Tor version ') and line.endswith('.'):
+            try:
+                version_str = line[12:-1]
+                return Version(version_str)
+            except ValueError as exc:
+                raise IOError(exc)
+    return Version(version_str)
+
+
+HASH_TYPES = True
+
+
+def _hash_value(val: Hashable):
+    if not HASH_TYPES:
+        my_hash = 0
+    else:
+        # TODO: I hate doing this but until Python 2.x support is dropped we
+        # can't readily be strict about bytes vs unicode for attributes. This
+        # is because test assertions often use strings, and normalizing this
+        # would require wrapping most with to_unicode() calls.
+        #
+        # This hack will go away when we drop Python 2.x support.
+
+        if isinstance(val, str):
+            my_hash = hash('str')
+        else:
+            # Hashing common builtins (ints, bools, etc) provide consistant values but many others vary their value on interpreter invokation.
+            my_hash = hash(str(type(val)))
+
+    if isinstance(val, (tuple, list)):
+        for v in val:
+            my_hash = (my_hash * 1024) + hash(v)
+    elif isinstance(val, dict):
+        for k in sorted(val.keys()):
+            my_hash = (my_hash * 2048) + (hash(k) * 1024) + hash(val[k])
+    else:
+        my_hash += hash(val)
+
+    return my_hash
+
+
+def _hash_attr(obj: Hashable, *attributes, **kwargs):
+    """
+    Provide a hash value for the given set of attributes.
+
+    :param Object obj: object to be hashed
+    :param list attributes: attribute names to take into account
+    :param bool cache: persists hash in a '_cached_hash' object attribute
+    :param class parent: include parent's hash value
+    """
+
+    is_cached = kwargs.get('cache', False)
+    parent_class = kwargs.get('parent', None)
+    cached_hash = getattr(obj, '_cached_hash', None)
+
+    if is_cached and cached_hash is not None:
+        return cached_hash
+
+    my_hash = parent_class.__hash__(obj) if parent_class else 0
+    my_hash = my_hash * 1024 + hash(str(type(obj)))
+
+    for attr in attributes:
+        val = getattr(obj, attr)
+        my_hash = my_hash * 1024 + _hash_value(val)
+
+    if is_cached:
+        setattr(obj, '_cached_hash', my_hash)
+
+    return my_hash
+
+
+@lru_cache()
+def get_version(version_str: str):
+    return Version(version_str)
+
+
+# An advantage over stem python is the inclusion of total_ordering
+@total_ordering
+class Version(object):
+    """
+    Comparable tor version. These are constructed from strings that conform to
+    the 'new' style in the `tor version-spec
+    <https://gitweb.torproject.org/torspec.git/tree/version-spec.txt>`_,
+    such as "0.1.4" or "0.2.2.23-alpha (git-7dcd105be34a4f44)".
+
+    .. versionchanged:: 1.6.0
+       Added all_extra parameter.
+
+    :var int major: major version
+    :var int minor: minor version
+    :var int micro: micro version
+    :var int patch: patch level (**None** if undefined)
+    :var str status: status tag such as 'alpha' or 'beta-dev' (**None** if undefined)
+    :var str extra: first extra information without its parentheses such as
+      'git-8be6058d8f31e578' (**None** if undefined)
+    :var list all_extra: all extra information entries, without their parentheses
+    :var str git_commit: git commit id (**None** if it wasn't provided)
+
+    :param str version_str: version to be parsed
+
+    :raises: **ValueError** if input isn't a valid tor version
+    """
+
+    __slots__ = (
+        'version_str',
+        'major',
+        'minor',
+        'micro',
+        'status',
+        'all_extra',
+        'extra',
+        'git_commit',
+        'patch',
+        '_cached_hash',
+    )
+
+    def __init__(self, version_str: str):
+        self.version_str = version_str
+        version_parts = VERSION_PATTERN.match(version_str)
+
+        if version_parts:
+            major, minor, micro, patch, status, extra_str, _ = version_parts.groups()
+
+            # The patch and status matches are optional (may be None) and have an extra
+            # proceeding period or dash if they exist. Stripping those off.
+
+            if patch:
+                patch = int(patch[1:])
+
+            if status:
+                status = status[1:]
+
+            self.major = int(major)
+            self.minor = int(minor)
+            self.micro = int(micro)
+            self.patch = patch
+            self.status = status
+            self.all_extra = (
+                [entry[1:-1] for entry in extra_str.strip().split()] if extra_str else []
+            )
+            self.extra = self.all_extra[0] if self.all_extra else None
+            self.git_commit = None
+
+            for extra in self.all_extra:
+                if extra and re.match('^git-[0-9a-f]{16}$', extra):
+                    self.git_commit = extra[4:]
+                    break
+        else:
+            raise ValueError("'%s' isn't a properly formatted tor version" % version_str)
+
+    def __str__(self):
+        """
+        Provides the string used to construct the version.
+        """
+
+        return self.version_str
+
+    def _compare(self, other: 'Version', method: Callable[[str, str], bool]):
+        """
+        Compares version ordering according to the spec.
+        """
+
+        if not isinstance(other, Version):
+            return False
+
+        for attr in ('major', 'minor', 'micro', 'patch'):
+            my_version = getattr(self, attr)
+            other_version = getattr(other, attr)
+
+            if my_version is None:
+                my_version = 0
+
+            if other_version is None:
+                other_version = 0
+
+            if my_version != other_version:
+                return method(my_version, other_version)
+
+        # According to the version spec...
+        #
+        #   If we *do* encounter two versions that differ only by status tag, we
+        #   compare them lexically as ASCII byte strings.
+
+        my_status = self.status if self.status else ''
+        other_status = other.status if other.status else ''
+
+        return method(my_status, other_status)
+
+    def __hash__(self):
+        return _hash_attr(self, 'major', 'minor', 'micro', 'patch', 'status', cache=True)
+
+    def __eq__(self, other):
+        return self._compare(other, lambda s, o: s == o)
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __gt__(self, other):
+        """
+        Checks if this version meets the requirements for a given feature. We can
+        be compared to either a :class:`~aiostem.version.Version` or
+        :class:`~aiostem.version._VersionRequirements`.
+        """
+
+        if isinstance(other, _VersionRequirements):
+            for rule in other.rules:
+                if rule(self):
+                    return True
+
+            return False
+
+        return self._compare(other, lambda s, o: s > o)
+
+    def __ge__(self, other):
+        if isinstance(other, _VersionRequirements):
+            for rule in other.rules:
+                if rule(self):
+                    return True
+
+            return False
+
+        return self._compare(other, lambda s, o: s >= o)
+
+
+class _VersionRequirements(object):
+    """
+    Series of version constraints that can be compared to. For instance, this
+    allows for comparisons like 'if I'm greater than version X in the 0.2.2
+    series, or greater than version Y in the 0.2.3 series'.
+
+    This is a logical 'or' of the series of rules.
+    """
+
+    __slots__ = 'rules'
+
+    def __init__(self):
+        self.rules: list[Callable[[Version], bool]] = []
+
+    def greater_than(self, version: Version, inclusive=True):
+        """
+        Adds a constraint that we're greater than the given version.
+
+        :param stem.version.Version version: version we're checking against
+        :param bool inclusive: if comparison is inclusive or not
+        """
+
+        if inclusive:
+            self.rules.append(lambda v: version <= v)
+        else:
+            self.rules.append(lambda v: version < v)
+
+    def less_than(self, version: Version, inclusive=True):
+        """
+        Adds a constraint that we're less than the given version.
+
+        :param stem.version.Version version: version we're checking against
+        :param bool inclusive: if comparison is inclusive or not
+        """
+
+        if inclusive:
+            self.rules.append(lambda v: version >= v)
+        else:
+            self.rules.append(lambda v: version > v)
+
+    def in_range(
+        self,
+        from_version: 'Version',
+        to_version: 'Version',
+        from_inclusive: bool = True,
+        to_inclusive: bool = False,
+    ):
+        """
+        Adds constraint that we're within the range from one version to another.
+
+        :param aiostem.version.Version from_version: beginning of the comparison range
+        :param aiostem.version.Version to_version: end of the comparison range
+        :param bool from_inclusive: if comparison is inclusive with the starting version
+        :param bool to_inclusive: if comparison is inclusive with the ending version
+        """
+        self.rules.append(
+            lambda v: (
+                (from_version <= v < to_version)
+                if to_inclusive
+                else (from_version <= v <= to_version)
+            )
+            if from_inclusive
+            else (from_version < v < to_version)
+        )
+
+
+safecookie_req = _VersionRequirements()
+safecookie_req.in_range(Version('0.2.2.36'), Version('0.2.3.0'))
+safecookie_req.greater_than(Version('0.2.3.13'))
+
+
+class Requirement(Enum):
+    """Versions Enums Reimplemented in aiohttp-tor and now uses a proper class which means it can all get typehinted correctly :)"""
+
+    AUTH_SAFECOOKIE = safecookie_req
+    DESCRIPTOR_COMPRESSION = Version('0.3.1.1-alpha')
+    DORMANT_MODE = Version('0.4.0.1-alpha')
+    DROPGUARDS = Version('0.2.5.1-alpha')
+    EVENT_AUTHDIR_NEWDESCS = Version('0.1.1.10-alpha')
+    EVENT_BUILDTIMEOUT_SET = Version('0.2.2.7-alpha')
+    EVENT_CIRC_MINOR = Version('0.2.3.11-alpha')
+    EVENT_CLIENTS_SEEN = Version('0.2.1.10-alpha')
+    EVENT_CONF_CHANGED = Version('0.2.3.3-alpha')
+    EVENT_DESCCHANGED = Version('0.1.2.2-alpha')
+    EVENT_GUARD = Version('0.1.2.5-alpha')
+    EVENT_HS_DESC_CONTENT = Version('0.2.7.1-alpha')
+    EVENT_NS = Version('0.1.2.3-alpha')
+    EVENT_NETWORK_LIVENESS = Version('0.2.7.2-alpha')
+    EVENT_NEWCONSENSUS = Version('0.2.1.13-alpha')
+    EVENT_SIGNAL = Version('0.2.3.1-alpha')
+    EVENT_STATUS = Version('0.1.2.3-alpha')
+    EVENT_STREAM_BW = Version('0.1.2.8-beta')
+    EVENT_TRANSPORT_LAUNCHED = Version('0.2.5.0-alpha')
+    EVENT_CONN_BW = Version('0.2.5.2-alpha')
+    EVENT_CIRC_BW = Version('0.2.5.2-alpha')
+    EVENT_CELL_STATS = Version('0.2.5.2-alpha')
+    EVENT_TB_EMPTY = Version('0.2.5.2-alpha')
+    EVENT_HS_DESC = Version('0.2.5.2-alpha')
+    EXTENDCIRCUIT_PATH_OPTIONAL = Version('0.2.2.9')
+    FEATURE_EXTENDED_EVENTS = Version('0.2.2.1-alpha')
+    FEATURE_VERBOSE_NAMES = Version('0.2.2.1-alpha')
+    GETINFO_CONFIG_TEXT = Version('0.2.2.7-alpha')
+    GETINFO_GEOIP_AVAILABLE = Version('0.3.2.1-alpha')
+    GETINFO_MICRODESCRIPTORS = Version('0.3.5.1-alpha')
+    GETINFO_UPTIME = Version('0.3.5.1-alpha')
+    HIDDEN_SERVICE_V3 = Version('0.3.3.1-alpha')
+    HSFETCH = Version('0.2.7.1-alpha')
+    HSFETCH_V3 = Version('0.4.1.1-alpha')
+    HSPOST = Version('0.2.7.1-alpha')
+    ADD_ONION = Version('0.2.7.1-alpha')
+    ADD_ONION_BASIC_AUTH = Version('0.2.9.1-alpha')
+    ADD_ONION_NON_ANONYMOUS = Version('0.2.9.3-alpha')
+    ADD_ONION_MAX_STREAMS = Version('0.2.7.2-alpha')
+    LOADCONF = Version('0.2.1.1')
+    MICRODESCRIPTOR_IS_DEFAULT = Version('0.2.3.3')
+    SAVECONF_FORCE = Version('0.3.1.1-alpha')
+    TAKEOWNERSHIP = Version('0.2.2.28-beta')
+    TORRC_CONTROL_SOCKET = Version('0.2.0.30')
+    TORRC_PORT_FORWARDING = Version('0.2.3.1-alpha')
+    TORRC_DISABLE_DEBUGGER_ATTACHMENT = Version('0.2.3.9')
+    TORRC_VIA_STDIN = Version('0.2.6.3-alpha')
+    ONION_SERVICE_AUTH_ADD = Version('0.4.6.1-alpha')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 	'Programming Language :: Python',
 	'Programming Language :: Python :: 3',
 	'Programming Language :: Python :: 3 :: Only',
+	'Programming Language :: Python :: 3.10',
 	'Programming Language :: Python :: 3.11',
 	'Programming Language :: Python :: 3.12',
 	'Programming Language :: Python :: 3.13',
@@ -28,9 +29,13 @@ classifiers = [
 ]
 dependencies = [
 	'cryptography >= 44.0, < 46.0',
-	'pydantic >= 2.9, < 3.0',
+	'pydantic >= 3.0',
+	'aiofiles >= 24.1.0',
+	'aiosignal >= 0.1.4',
+	'frozenlist >= 1.7.0',
+	'async_lru >= 2.0.5'
 ]
-requires-python = '>=3.11'
+requires-python = '>=3.10'
 
 [project.urls]
 Changelog = 'https://github.com/morian/aiostem/blob/master/CHANGELOG.rst'

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -5,13 +5,13 @@ import gc
 import hashlib
 import logging
 import weakref
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 from ipaddress import IPv4Address, IPv6Address
-
 import pytest
 import pytest_asyncio
 from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
 from pydantic import ValidationError
+
 
 from aiostem.event import (
     EventBandwidth,
@@ -53,6 +53,7 @@ from aiostem.structures import (
     StatusActionGeneral,
 )
 from aiostem.utils import MessageData, TrRSAPublicKey
+from aiostem.utils.backports import UTC
 
 from .test_reply import create_message
 

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -1,12 +1,29 @@
 from __future__ import annotations
 
 import aiostem
+from aiostem.version import Version
 
 
-class TestVersion:
+class TestPackageVersion:
     def test_version_attribute_is_present(self):
         assert hasattr(aiostem, '__version__')
 
     def test_version_attribute_is_a_string(self):
         assert isinstance(aiostem.__version__, str)
         assert aiostem.version == aiostem.__version__
+
+
+class TestVersion:
+    def test_version_gt(self):
+        assert Version('2.2.2') > Version('1.1.1')
+
+    def test_version_lt(self):
+        assert Version('1.1.1') < Version('2.2.2')
+
+    def test_version_ge(self):
+        assert Version('2.2.2') >= Version('1.1.1')
+        assert Version('2.2.2') >= Version('2.2.2')
+
+    def test_version_le(self):
+        assert Version('1.1.1') <= Version('2.2.2')
+        assert Version('2.2.2') <= Version('2.2.2')

--- a/tests/utils/test_transformers.py
+++ b/tests/utils/test_transformers.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from base64 import b32decode, b64decode
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 from typing import Annotated, Any
+
 
 import pytest
 from cryptography.hazmat.primitives.asymmetric.ed25519 import (
@@ -30,6 +31,7 @@ from aiostem.utils import (
     TrRSAPublicKey,
     TrX25519PrivateKey,
     TrX25519PublicKey,
+    UTC,  # Backported for 3.10
 )
 
 


### PR DESCRIPTION
3.9 May haven't been possible but I was able to backport many things that 3.10 doesn't have which include
- `StrEnum` , `UTC` & `Self` (typing-extensions)
- I fixed a few bugs with 3.10 as well which are mainly protocol and schema related so Only needing to make checks for those felt appropriate for the time being.
- I added a few extra things that the original tor stem library uses such as versions and other system related things for checking the version.
- I'm not so sure how testing process launching should be performed since I've had problems writing my own tests (an example is a Dummy DNSServer for benchmarking a DnsResolver) where a github repo temporarily hosts a dummy server but later closes it.
