### PR TITLE
Bring back support for Python 3.10 while minimizing changes.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.10'
 
       - name: Install build dependencies
         run: make install-package

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
       - name: Repository checkout

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -90,14 +90,17 @@ typing:
   allow_failure: true
 
 tests:
-  image: ${CI_REGISTRY}/dockers/ci/python-build:3.13-alpine
+  parallel:
+    matrix:
+      - PYTHON_VERSION: ['3.10', '3.11', '3.12', '3.13']
+  image: ${CI_REGISTRY}/dockers/ci/python-build:${PYTHON_VERSION}-alpine
   stage: tests
   needs: []
   variables:
     AIOSTEM_HOST: 'torcontrol'
     AIOSTEM_PASS: 'aiostem'
   services:
-    - name: "${CI_REGISTRY}/${CI_PROJECT_ROOT_NAMESPACE}/docker/tor-client:0.4.8.16"
+    - name: "${CI_REGISTRY}/${CI_PROJECT_ROOT_NAMESPACE}/docker/tor-client:0.4.8.17"
       alias: torcontrol
       command: [
         'tor',

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,14 @@ The format is based on `Keep a Changelog`_ and this project adheres to `Semantic
 .. _Semantic Versioning: https://semver.org/spec/v2.0.0.html
 
 
+0.4.5 (UNRELEASED)
+==================
+
+Added
+-----
+- Brought back support for Python 3.10 as suggested by @Vizonex
+
+
 0.4.4 (2025-05-04)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ know exactly what is performed under the hood. It has also become too complex an
 legacy code, both for a large range of Python versions and support for old versions of Tor.
 
 ``Tor v0.4.x`` has been released for many years now, therefore ``aiostem`` focuses the support
-for ``Tor v0.4.5`` and later, as well as Python 3.11 and later.
+for ``Tor v0.4.5`` and later, as well as Python 3.10 and later.
 
 Additionally, ``stem`` does not provide a low-level API around the control protocol, which
 means that there is time waster registering and unregistering events all around. ``aistem``
@@ -66,7 +66,7 @@ following features:
 Installation
 ------------
 
-This package requires Python ≥ 3.11 and pulls a few other packages as dependencies
+This package requires Python ≥ 3.10 and pulls a few other packages as dependencies
 such as pydantic_ for serialization, deserialization and validation of received data,
 and cryptography_ to deal with the various keys used by Tor.
 

--- a/aiostem/command.py
+++ b/aiostem/command.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import secrets
 from collections.abc import Mapping, MutableMapping, MutableSequence
 from dataclasses import dataclass, field
-from enum import StrEnum
-from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Literal, Self, Union
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Literal, Union
 
 from pydantic import Discriminator, NonNegativeInt, Tag, TypeAdapter
 from pydantic_core import core_schema
@@ -31,8 +30,14 @@ from .structures import (
     VirtualPort,
 )
 from .types import AnyHost, AnyPort, Base16Bytes, BoolYesNo
-from .utils.argument import ArgumentKeyword, ArgumentString, QuoteStyle
-from .utils.transformers import TrBeforeStringSplit
+from .utils import (
+    ArgumentKeyword,
+    ArgumentString,
+    QuoteStyle,
+    Self,
+    StrEnum,
+    TrBeforeStringSplit,
+)
 
 if TYPE_CHECKING:
     from pydantic import GetCoreSchemaHandler

--- a/aiostem/controller.py
+++ b/aiostem/controller.py
@@ -104,7 +104,7 @@ from .structures import (
     StreamCloseReasonInt,
     VirtualPortTarget,
 )
-from .utils import Message, messages_from_stream
+from .utils import Message, Self, messages_from_stream
 
 if TYPE_CHECKING:
     from collections.abc import (  # noqa: F401
@@ -115,7 +115,6 @@ if TYPE_CHECKING:
         Set as AbstractSet,
     )
     from types import TracebackType
-    from typing import Self
 
     from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
     from cryptography.hazmat.primitives.asymmetric.x25519 import (

--- a/aiostem/event.py
+++ b/aiostem/event.py
@@ -8,9 +8,8 @@ from collections.abc import (
     Set as AbstractSet,
 )
 from dataclasses import dataclass, field
-from enum import StrEnum
 from functools import cached_property
-from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Literal, Self, TypeAlias, Union
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Literal, TypeAlias, Union
 
 from pydantic import BeforeValidator, Discriminator, Field, NonNegativeInt, Tag, TypeAdapter
 
@@ -85,6 +84,8 @@ from .utils import (
     MessageData,
     ReplySyntax,
     ReplySyntaxFlag,
+    Self,
+    StrEnum,
     TrBeforeSetToNone,
     TrBeforeStringSplit,
     TrCast,

--- a/aiostem/monitor.py
+++ b/aiostem/monitor.py
@@ -12,11 +12,10 @@ from pydantic import NonNegativeInt
 from .event import Event, EventNetworkLiveness, EventStatusClient, EventWord
 from .exceptions import ControllerError, ReplyStatusError
 from .structures import Signal, StatusActionClient, StatusClientBootstrap
-from .utils import Message
+from .utils import Message, Self
 
 if TYPE_CHECKING:
     from types import TracebackType
-    from typing import Self
 
     from .controller import Controller
 

--- a/aiostem/reply.py
+++ b/aiostem/reply.py
@@ -14,7 +14,7 @@ from collections.abc import (
 )
 from dataclasses import dataclass, field
 from functools import partial
-from typing import Any, ClassVar, Self, TypeAlias, TypeVar
+from typing import Any, ClassVar, TypeAlias, TypeVar
 
 from pydantic import PositiveInt, TypeAdapter
 
@@ -27,7 +27,7 @@ from .structures import (
     ReplyDataOnionClientAuthView,
     ReplyDataProtocolInfo,
 )
-from .utils import BaseMessage, Message, ReplySyntax, ReplySyntaxFlag
+from .utils import BaseMessage, Message, ReplySyntax, ReplySyntaxFlag, Self
 
 logger = logging.getLogger(__package__)
 

--- a/aiostem/structures.py
+++ b/aiostem/structures.py
@@ -15,8 +15,8 @@ from collections.abc import (
 )
 from contextlib import suppress
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
-from enum import IntEnum, IntFlag, StrEnum
+from datetime import datetime, timezone
+from enum import IntEnum, IntFlag
 from functools import cache, cached_property, wraps
 from ipaddress import IPv4Address, IPv6Address
 from typing import (
@@ -26,7 +26,6 @@ from typing import (
     ClassVar,
     Literal,
     Optional,
-    Self,
     TypeAlias,
     Union,
     cast,
@@ -75,6 +74,8 @@ from .types import (
 from .utils import (
     Base64Encoder,
     EncodedBytes,
+    Self,
+    StrEnum,
     TrBeforeSetToNone,
     TrBeforeStringSplit,
     TrCast,
@@ -577,7 +578,7 @@ class Ed25519CertificateV1(Ed25519Certificate):
     @property
     def expired(self) -> bool:
         """Tell whether this certificate has expired."""
-        return bool(datetime.now(UTC) > self.expiration)
+        return bool(datetime.now(timezone.utc) > self.expiration)
 
     @cached_property
     def signing_key(self) -> Ed25519PublicKey | None:

--- a/aiostem/utils/__init__.py
+++ b/aiostem/utils/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from .argument import ArgumentKeyword, ArgumentString, QuoteStyle
+from .backports import Self, StrEnum
 from .encoding import (
     Base16Encoder,
     Base32Encoder,
@@ -42,6 +43,8 @@ __all__ = [
     'QuoteStyle',
     'ReplySyntax',
     'ReplySyntaxFlag',
+    'Self',
+    'StrEnum',
     'TrAfterAsTimezone',
     'TrBeforeSetToNone',
     'TrBeforeStringSplit',

--- a/aiostem/utils/argument.py
+++ b/aiostem/utils/argument.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import re
 from abc import ABC, abstractmethod
-from enum import IntEnum, StrEnum
+from enum import IntEnum
 from ipaddress import IPv4Address, IPv6Address
-from typing import TYPE_CHECKING, Any, TypeAlias, Union, overload
+from typing import TYPE_CHECKING, Any, TypeAlias, Union, cast, overload
+
+from .backports import StrEnum
 
 if TYPE_CHECKING:
     from collections.abc import Set as AbstractSet
@@ -168,7 +170,7 @@ class ArgumentKeyword(BaseArgument):
         """Serialize the argument to a string."""
         if self._value is None:
             # This check was already performed during __init__.
-            return self._key  # type: ignore[return-value]
+            return cast('str', self._key)
 
         value = self._quotes.escape(self._value)
         if self._key is None:

--- a/aiostem/utils/backports.py
+++ b/aiostem/utils/backports.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+if sys.version_info >= (3, 11, 0) and not TYPE_CHECKING:
+    from enum import StrEnum
+    from typing import Self
+else:
+    from enum import Enum
+
+    from typing_extensions import Self
+
+    class StrEnum(str, Enum):
+        """Backport for StrEnum from Python 3.11."""
+
+        __str__ = str.__str__
+
+
+__all__ = [
+    'Self',
+    'StrEnum',
+]

--- a/aiostem/utils/transformers.py
+++ b/aiostem/utils/transformers.py
@@ -11,7 +11,7 @@ from collections.abc import (
     Set as AbstractSet,
 )
 from dataclasses import dataclass, field
-from datetime import UTC, datetime, timedelta, tzinfo
+from datetime import datetime, timedelta, timezone, tzinfo
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, Literal, TypeVar
 
 from cryptography.hazmat.primitives.asymmetric.ed25519 import (
@@ -42,7 +42,7 @@ class TrAfterAsTimezone:
     """Post-validator that enforces a timezone."""
 
     #: Timezone to map this date to.
-    timezone: tzinfo = UTC
+    timezone: tzinfo = timezone.utc
 
     def __get_pydantic_core_schema__(
         self,

--- a/aiostem/version.py
+++ b/aiostem/version.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-version: str = '0.4.4'
+version: str = '0.4.5'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,6 +101,9 @@ typehints_use_rtype = False
 napoleon_preprocess_types = True
 napoleon_use_admonition_for_notes = True
 
+# Pygment color scheme.
+pygments_style = 'github-dark'
+
 
 # InterSphinx
 intersphinx_mapping = {

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -4,7 +4,7 @@ Getting started
 Requirements
 ------------
 
-``aiostem`` requires Python ≥ 3.11.
+``aiostem`` requires Python ≥ 3.10.
 
 
 .. admonition:: Use the most recent Python release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 	'Programming Language :: Python',
 	'Programming Language :: Python :: 3',
 	'Programming Language :: Python :: 3 :: Only',
+	'Programming Language :: Python :: 3.10',
 	'Programming Language :: Python :: 3.11',
 	'Programming Language :: Python :: 3.12',
 	'Programming Language :: Python :: 3.13',
@@ -29,8 +30,9 @@ classifiers = [
 dependencies = [
 	'cryptography >= 44.0, < 46.0',
 	'pydantic >= 2.9, < 3.0',
+	'typing_extensions > 4.0; python_version < "3.11"',
 ]
-requires-python = '>=3.11'
+requires-python = '>=3.10'
 
 [project.urls]
 Changelog = 'https://github.com/morian/aiostem/blob/master/CHANGELOG.rst'
@@ -166,7 +168,7 @@ max-complexity = 12
 [tool.mypy]
 files = ['aiostem/**/*.py']
 plugins = ['pydantic.mypy']
-python_version = '3.11'
+python_version = '3.10'
 namespace_packages = true
 explicit_package_bases = true
 show_error_codes = true

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -5,7 +5,7 @@ import gc
 import hashlib
 import logging
 import weakref
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from ipaddress import IPv4Address, IPv6Address
 
 import pytest
@@ -600,7 +600,7 @@ class TestEvents:
         assert event.original == IPv6Address('2a04:fa87:fffd::c000:426c')
         assert event.replacement is None
         assert isinstance(event.expires, datetime)
-        assert event.expires.tzinfo == UTC
+        assert event.expires.tzinfo == timezone.utc
         assert event.stream == 110330
         assert event.cached is False
         assert event.error == 'yes'

--- a/tests/utils/test_transformers.py
+++ b/tests/utils/test_transformers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from base64 import b32decode, b64decode
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Annotated, Any
 
 import pytest
@@ -38,7 +38,7 @@ class TestAsTimezone:
         ('raw', 'timezone', 'timestamp'),
         [
             ('2024-12-09T23:10:14+01:00', None, 1733782214),
-            ('2024-12-09T23:10:14', UTC, 1733785814),
+            ('2024-12-09T23:10:14', timezone.utc, 1733785814),
         ],
     )
     def test_astimezone(self, raw, timezone, timestamp):


### PR DESCRIPTION
This pull request follows a suggestion by @Vizonex in issue #1.

Code was updated in the following way:
- `datetime.UTC` is now directly taken from `datetime.timzone.utc`
- `StrEnum` is rebuilt when running Python 3.10
- `Self` typing argument is taken from `typing_extensions` which is a 3.10 only dependency.

Tests were also updated, including:
- `datetime.UTC` fix, similar to the one mentioned above.
- A new 3.10 entry was added in GitHub and Gitlab test matrices.
- Documentation was updated as well, preparing for a future release (`v0.4.5`)